### PR TITLE
feat: local preview server functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,6 +466,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1553,6 +1559,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/async": "^3.2.6",
+    "@types/cors": "^2.8.12",
     "@types/express": "^4.17.12",
     "@types/flat": "^5.0.1",
     "@types/http-proxy": "^1.17.6",
@@ -59,6 +60,7 @@
     "@octokit/rest": "^18.6.6",
     "@types/keyv": "^3.1.1",
     "commander": "^8.0.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "google-auth-library": "^7.2.0",
     "googleapis": "^80.1.0",


### PR DESCRIPTION
Allow the preview plugin to serve the editor preview server config when running in a dev environment. This removes the github syncing but allows for a local server to serve the correct preview server config.

CORS headers are needed for local preview server to work.